### PR TITLE
Fix Librispeech + Support Python3.6

### DIFF
--- a/examples/librispeech/config.json
+++ b/examples/librispeech/config.json
@@ -1,27 +1,37 @@
 {
-    "seed" : 2017,
+    "seed" : 2019,
     "save_path" : "/deep/group/awni/speech_models/test",
 
     "data" : {
         "train_set" : "/deep/group/speech/datasets/LibriSpeech/train-toy.json",
-        "dev_set" : "/deep/group/speech/datasets/LibriSpeech/dev-toy.json"
+        "dev_set" : "/deep/group/speech/datasets/LibriSpeech/dev-toy.json",
+        "start_and_end" : false
     },
 
     "optimizer" : {
         "batch_size" : 8,
-        "epochs" : 1000,
+        "epochs" : 200,
         "learning_rate" : 1e-3,
         "momentum" : 0.0
     },
 
     "model" : {
+        "class" : "Transducer",
+        "dropout" : 0.5,
         "encoder" : {
+            "conv" : [
+                [8, 5, 32, 2],
+                [8, 5, 32, 1]
+            ],
             "rnn" : {
                 "dim" : 256,
-                "layers" : 1
+                "bidirectional" : true,
+                "layers" : 4
             }
         },
         "decoder" : {
+            "embedding_dim" : 256,
+            "layers" : 1
         }
     }
 }

--- a/train.py
+++ b/train.py
@@ -24,6 +24,7 @@ def run_epoch(model, optimizer, train_ldr, it, avg_loss):
     end_t = time.time()
     tq = tqdm.tqdm(train_ldr)
     for batch in tq:
+        batch = list(batch)
         start_t = time.time()
         optimizer.zero_grad()
         loss = model.loss(batch)
@@ -54,6 +55,7 @@ def eval_dev(model, ldr, preproc):
     model.set_eval()
 
     for batch in tqdm.tqdm(ldr):
+        batch = list(batch)
         preds = model.infer(batch)
         loss = model.loss(batch)
         losses.append(loss.data[0])


### PR DESCRIPTION
LibirSpeech Config was out of date, therefore updated and seed changed to 2019 just as proof of change.
Changed train.py and added batch=list(batch) twice, because zipped objects terminate after 1 epoch.